### PR TITLE
add groupElements option to bp

### DIFF
--- a/assets/coffee/main.coffee
+++ b/assets/coffee/main.coffee
@@ -10,6 +10,12 @@ $.fn.toggler = (options = {}) ->
     selector = $el.selector
     resizeTimer = null
 
+    #  groupElments apply actions to all occurring togglers
+    if !!options.groupElement
+      for singleClass in $(@).attr('class').split(/\s+/)
+        if +(singleClass.search /js-/) != -1
+          options.elmts = $('.' + singleClass)
+
     getTarget = (el) ->
       $($(el).data('target'))
 
@@ -41,6 +47,9 @@ $.fn.toggler = (options = {}) ->
       $target = getTarget($el)
 
       fn = if active then 'addClass' else 'removeClass'
+
+      if !!options.groupElement
+        $el = options.elmts  #change el to a group el
 
       setOn($el, !active)
       $target[fn](options.activeClass)


### PR DESCRIPTION
- Created a new option groupElements
- had a check see if there is a group elements option enabled and set it when initializing
- had another check run where classes are applied in setShow() function and applied the classes to all occurring $el that share a js- class name (this part can be improved with a data option for name of shared toggle or something of that sort)
