### PR TITLE
Fix click off when elements exception is not the parent of the toggler.

### DIFF
--- a/assets/js/lib/toggler.js
+++ b/assets/js/lib/toggler.js
@@ -9,6 +9,7 @@ export default $.fn.toggler = function(options) {
   return this.each(function() {
     var $el, getTarget, getToggleText, i, isOn, isWideEnough, len, ref, resizeTimer, selector, setElems, setOn, setShow, singleClass, togglePress;
     $el = $(this);
+    $el.canClickOff = true; // add var to manage clickoff
     options.activeClass || (options.activeClass = 'is-active');
     options.activeTriggerClass || (options.activeTriggerClass = 'is-active');
     options.closeTarget || (options.closeTarget = false);
@@ -87,6 +88,7 @@ export default $.fn.toggler = function(options) {
         if (e.target === $el[index] || [].slice.call($el.children()).indexOf(e.target) > -1) {
           e.preventDefault();
           togglePress($el);
+          $el.canClickOff = false; //prevent clickoff exception
           return false;
         }
       });
@@ -99,9 +101,10 @@ export default $.fn.toggler = function(options) {
     $(self.document).on('click touch', $el, function(e) {
       var $exceptEl;
       $exceptEl = $($el.data('click-off-exception'));
-      if ($el.data('click-off') === 'on' && isWideEnough($el) && ([].indexOf.call($exceptEl, e.target) === -1 && !$exceptEl.find(e.target).length)) {
+      if ($el.canClickOff && $el.data('click-off') === 'on' && isWideEnough($el) && ([].indexOf.call($exceptEl, e.target) === -1 && !$exceptEl.find(e.target).length)) {
         setShow($el, false);
       }
+      $el.canClickOff = true; //enable clickoff exception
     });
 
     return setElems($el);


### PR DESCRIPTION
To elaborate the markup was as follow

div
> a .toggler [data-clickoff-exception=form] [data-target=form]
form

Now when the toggler was clicked it closed the form. I needed click off to work. Therefore I disabled click off for the first occurrence (Which seem to fire always) after every toggle click for the specific jQuery element $el. 

The alternative was to disable click off exception, but I thought that is not good UX.
