### PR TITLE
Function primaryMenu() passes $options params down

### DIFF
--- a/controllers/traits/menu_factory.php
+++ b/controllers/traits/menu_factory.php
@@ -11,9 +11,9 @@ trait MenuFactory
 
     public function primaryMenu($options = array())
     {
-        return $this->__renderMenu(array(
+        return $this->__renderMenu(array_merge(array(
             'outer_tpl' => '<ul class="menu--primary js-menu-primary">||</ul>',
-        ));
+        ), $options));
     }
 
     private function __renderMenu($options = array())


### PR DESCRIPTION
* This bug isn't in the develop branch as `controllers/traits/menu_factory.php` is replaced by `controllers/traits/primary_menu.php`

This fixes a bug where you can't modify options passed to MarkupSimpleNav with the `primaryMenu()` function.

This was because `$options` is never passed down to `private function __renderMenu` from `public function primaryMenu`.

We can now render additional options by calling primaryMenu() as shown below:

```
<?= $this->primaryMenu(array('list_field_class' => 'menu-class--alt')) ?> // works
```